### PR TITLE
Rename of package and related code

### DIFF
--- a/grabber.go
+++ b/grabber.go
@@ -3,7 +3,7 @@
 // name it for the time being) includes some helper functions for
 // dealing with models.  UnmarshalParams is the big utility function
 // of this library, but other helpers may show up in the future.
-package model_helpers
+package rest_grab
 
 import (
 	"errors"

--- a/grabber.go
+++ b/grabber.go
@@ -111,7 +111,7 @@ func setValue(target reflect.Value, value interface{}) (parseErr error) {
 	receiver, ok := target.Interface().(Receiver)
 	if !ok && target.CanAddr() {
 		// Try again with the pointer
-		receiver, ok = target.Addr().Interface().(Receiver)
+		puller, ok = target.Addr().Interface().(Puller)
 	}
 
 	if ok {

--- a/missing_fields_error.go
+++ b/missing_fields_error.go
@@ -1,4 +1,4 @@
-package model_helpers
+package rest_grab
 
 import (
 	"strings"

--- a/puller.go
+++ b/puller.go
@@ -1,13 +1,13 @@
-package model_helpers
+package grabber
 
 // A Receiver is a type that performs its own logic related to
 // receiving data from a request.  This is useful for password types
 // (to automatically hash the value) or anything that needs to perform
 // some type of validation.
-type Receiver interface {
+type Puller interface {
 	// Receive takes a value (as would be sent in a request) and
 	// attempts to read set the Receiver's value to match the passed
 	// in value.  It returns an error if the value isn't valid or
 	// can't be parsed to the Receiver.
-	Receive(interface{}) error
+	Pull(interface{}) error
 }

--- a/puller.go
+++ b/puller.go
@@ -1,4 +1,4 @@
-package grabber
+package rest_grab
 
 // A Receiver is a type that performs its own logic related to
 // receiving data from a request.  This is useful for password types


### PR DESCRIPTION
The previous names were boring.  Without needing to use REST verbs (they're also boring), use new names that are easy to remember and are just as explicit in description.
